### PR TITLE
Maintains order when deduplicating

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -10,7 +10,7 @@ const tests = [{
 }, {
     message: 'should remove duplicate rules (2)',
     fixture: 'h1{color:#000}h2{color:#fff}h1{color:#000}',
-    expected: 'h2{color:#fff}h1{color:#000}',
+    expected: 'h1{color:#000}h2{color:#fff}',
 }, {
     message: 'should remove duplicate declarations',
     fixture: 'h1{font-weight:bold;font-weight:bold}',
@@ -26,7 +26,7 @@ const tests = [{
 }, {
     message: 'should remove duplicate @rules (2)',
     fixture: '@charset "utf-8";@charset "hello!";@charset "utf-8";',
-    expected: '@charset "hello!";@charset "utf-8";',
+    expected: '@charset "utf-8";@charset "hello!";',
 }, {
     message: 'should remove duplicates inside @media queries',
     fixture: '@media print{h1{display:block}h1{display:block}}',
@@ -78,7 +78,7 @@ const tests = [{
 }, {
     message: 'should remove duplicate rules and declarations',
     fixture: 'h1{color:#000}h2{color:#fff}h1{color:#000;color:#000}',
-    expected: 'h2{color:#fff}h1{color:#000}',
+    expected: 'h1{color:#000}h2{color:#fff}',
 }];
 
 tests.forEach(test => {

--- a/src/index.js
+++ b/src/index.js
@@ -26,8 +26,10 @@ function dedupe (root) {
             }
         }
 
-        for (let i = result.length - 2; ~i; i -= 1) {
-            result[i].remove();
+        let len = result.length;
+        while (len > 1) {
+            result[len - 1].remove();
+            len--;
         }
     });
 }


### PR DESCRIPTION
Sometimes the order of css selectors matter - especially when using css-modules.

Spun the de-deduplication logic around so it leaves the first instance of a selector - not the last.
