### PR TITLE
Add option to reverse the removal order

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,55 @@ h1 {
 See the [PostCSS documentation](https://github.com/postcss/postcss#usage) for
 examples for your environment.
 
+## Removal Order
+
+By default, duplicate css rules will be removed in a top down fashion:
+#### Input
+
+```css
+h1 {
+    margin: 0 auto;
+}
+h2 {
+    margin: 0 auto;
+}
+h1 {
+    margin: 0 auto;
+}
+```
+
+#### Output
+
+```css
+h2 {
+    margin: 0 auto;
+}
+h1 {
+    margin: 0 auto;
+}
+```
+
+To reverse this behavior and remove in a bottom up fashion, set the option `reverseRemoval` to `true`:
+
+```js
+postcss([
+    require('postcss-discard-duplicates')({
+        reverseRemoval: true
+    })
+])
+```
+
+#### Output
+
+```css
+h1 {
+    margin: 0 auto;
+}
+h2 {
+    margin: 0 auto;
+}
+```
+
 ## Contributors
 
 Thanks goes to these wonderful people ([emoji key](https://github.com/kentcdodds/all-contributors#emoji-key)):

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -95,6 +95,20 @@ const tests = [{
     message: 'should preserve browser hacks (2)',
     fixture: '@media \0 all {}@media all {}',
     expected: '@media \0 all {}@media all {}',
+}, {
+    message: 'should remove duplicate rules and declarations in reverse order',
+    fixture: 'h1{color:#000}h2{color:#fff}h1{color:#000;color:#000}',
+    expected: 'h1{color:#000}h2{color:#fff}',
+    options: {
+        reverseRemoval: true,
+    },
+}, {
+    message: 'should remove partial duplicates in reverse order',
+    fixture: 'h1{color:red;background:blue}h1{color:red}',
+    expected: 'h1{color:red;background:blue}',
+    options: {
+        reverseRemoval: true,
+    },
 }];
 
 tests.forEach(test => {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,7 @@
 import {plugin} from 'postcss';
 
+let options = {};
+
 function noop () {}
 
 function trimValue (value) {
@@ -84,8 +86,9 @@ function dedupeRule (last, nodes) {
                 }
             });
 
-            if (empty(node)) {
-                node.remove();
+            const targetNode = options.reverseRemoval ? last : node;
+            if (empty(targetNode)) {
+                targetNode.remove();
             }
         }
     }
@@ -98,8 +101,9 @@ function dedupeNode (last, nodes) {
 
     while (index >= 0) {
         const node = nodes[index--];
+        const targetNode = options.reverseRemoval ? last : node;
         if (node && equals(node, last)) {
-            node.remove();
+            targetNode.remove();
         }
     }
 }
@@ -129,4 +133,9 @@ function dedupe (root) {
     }
 }
 
-export default plugin('postcss-discard-duplicates', () => dedupe);
+function discardDuplicates (opts) {
+    options = opts || options;
+    return dedupe;
+}
+
+export default plugin('postcss-discard-duplicates', discardDuplicates);


### PR DESCRIPTION
Useful for removing css from chunk stylesheets that is already found in a common stylesheet.