### PR TITLE
bump postcss version

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "postcss": "^5.0.4"
+    "postcss": "^6.0.0"
   },
   "devDependencies": {
     "all-contributors-cli": "^3.0.5",


### PR DESCRIPTION
Seems as though none of the [breaking changes](https://github.com/postcss/postcss/releases/tag/6.0.0) applies to anything that is being done in this project.